### PR TITLE
Add extra check to guard against non-actions

### DIFF
--- a/eth/filter_errors.js
+++ b/eth/filter_errors.js
@@ -30,7 +30,20 @@ function setErrors(traces) {
 
 }
 
+/** Remove traces which contain no useful data. For example:
+ {
+     "error": {
+         "code": -32000,
+         "message": "first run for txIndex 323 error: insufficient funds for gas * price + value: address 0xb64a30399f7F6b0C154c2E7Af0a3ec7B0A5b131a have 79011297267895730 want 79314366712002216"
+     }
+ }
+*/
+function filterNonActions(traces) {
+  return traces.filter(trace => typeof trace.action != 'undefined')
+}
+
 function filterErrors(traces) {
+  traces = filterNonActions(traces)
   traces = setErrors(traces)
   traces = traces.filter(trace => typeof trace.error === 'undefined')
   return traces

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,6 +2,7 @@ const assert = require("assert")
 
 const { filterErrors } = require('../eth')
 const testErrTxs = require('./test_err_txs.json')
+const testErrTxsNonAction = require('./test_err_txs_non_action.json')
 const testParentErr = require('./test_parent_err.json')
 
 describe('Find errors', function () {
@@ -9,6 +10,15 @@ describe('Find errors', function () {
     assert.strictEqual(
       filterErrors(testErrTxs).length,
       1
+    )
+  })
+})
+
+describe('Find errors non action', function () {
+  it('Test that if a non-action is returned it would not break us', function () {
+    assert.strictEqual(
+      filterErrors(testErrTxsNonAction).length,
+      0
     )
   })
 })

--- a/test/test_err_txs_non_action.json
+++ b/test/test_err_txs_non_action.json
@@ -1,0 +1,8 @@
+[
+    {
+        "error": {
+            "code": -32000,
+            "message": "first run for txIndex 323 error: insufficient funds for gas * price + value: address 0xb64a30399f7F6b0C154c2E7Af0a3ec7B0A5b131a have 79011297267895730 want 79314366712002216"
+        }
+    }
+]


### PR DESCRIPTION
The Full Node now returns unexpected format which breaks the exporter.

https://www.notion.so/santiment/ETH-transfers-exporter-is-stuck-122fdf9235c14b2a9daf72001d368724